### PR TITLE
Allow to change Gradio server ip. Workaround an setup error

### DIFF
--- a/docs/prepare_env/install_guide-zh.md
+++ b/docs/prepare_env/install_guide-zh.md
@@ -37,5 +37,14 @@ mim install mmcv==2.1.0 # 使用mim来加速mmcv安装
 # 其他依赖项
 pip install -r docs/prepare_env/requirements.txt -v
 
+
+如果你遇到如下错误，请尝试使用以下命令安装依赖项：
+pip install -r docs/prepare_env/requirements.txt -v --use-deprecated=legacy-resolver
+
+> ERROR: pip's dependency resolver does not currently take into account all the packages
+> that are installed. This behaviour is the source of the following dependency conflicts.
+> openxlab 0.0.34 requires setuptools~=60.2.0, but you have setuptools 69.1.1 which is incompatible.
+
+
 ```
 

--- a/docs/prepare_env/install_guide.md
+++ b/docs/prepare_env/install_guide.md
@@ -34,4 +34,11 @@ mim install mmcv==2.1.0 # use mim to speed up installation for mmcv
 # other dependencies
 pip install -r docs/prepare_env/requirements.txt -v
 
+If you encounter the following error, please try to install the dependencies with the following command:
+pip install -r docs/prepare_env/requirements.txt -v --use-deprecated=legacy-resolver
+
+> ERROR: pip's dependency resolver does not currently take into account all the packages
+> that are installed. This behaviour is the source of the following dependency conflicts.
+> openxlab 0.0.34 requires setuptools~=60.2.0, but you have setuptools 69.1.1 which is incompatible.
+
 ```

--- a/inference/app_real3dportrait.py
+++ b/inference/app_real3dportrait.py
@@ -232,6 +232,8 @@ if __name__ == "__main__":
     parser.add_argument("--head_ckpt", type=str, default='')
     parser.add_argument("--torso_ckpt", type=str, default='checkpoints/240210_real3dportrait_orig/secc2plane_torso_orig/model_ckpt_steps_100000.ckpt') 
     parser.add_argument("--port", type=int, default=None) 
+    parser.add_argument("--server", type=str, default='127.0.0.1')
+
     args = parser.parse_args()
     demo = real3dportrait_demo(
         audio2secc_dir=args.a2m_ckpt,
@@ -241,5 +243,4 @@ if __name__ == "__main__":
         warpfn=None,
     )
     demo.queue()
-    demo.launch(server_port=args.port)
-
+    demo.launch(server_name=args.server, server_port=args.port)


### PR DESCRIPTION
I encountered an error when installing the requirements.txt. A workaround fix is provided in this pull.

ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
openxlab 0.0.34 requires setuptools~=60.2.0, but you have setuptools 69.1.1 which is incompatible.


For the error: The root cause is that one of the python package had strict version requirements on setuptools. The root dep tree node is "openmim==0.3.9". Unfortunately, all major dep tree nodes are the latest version. So hopefully a future version of openmim / openxlab have removed the restriction.
